### PR TITLE
Support specifying the output format of fetch features with a query parameter

### DIFF
--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/autoconfigure/ApiAutoConfiguration.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/autoconfigure/ApiAutoConfiguration.java
@@ -1,9 +1,17 @@
 package com.camptocamp.opendata.ogc.features.autoconfigure;
 
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Enumeration;
+import java.util.List;
+
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
 
+import com.camptocamp.opendata.ogc.features.http.codec.MimeTypes;
 import com.camptocamp.opendata.ogc.features.repository.CollectionRepository;
 import com.camptocamp.opendata.ogc.features.server.api.CollectionsApiController;
 import com.camptocamp.opendata.ogc.features.server.api.CollectionsApiDelegate;
@@ -11,14 +19,17 @@ import com.camptocamp.opendata.ogc.features.server.config.HomeController;
 import com.camptocamp.opendata.ogc.features.server.config.SpringDocConfiguration;
 import com.camptocamp.opendata.ogc.features.server.impl.CollectionsApiImpl;
 
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequestWrapper;
+
 @AutoConfiguration
 @Import(SpringDocConfiguration.class)
 public class ApiAutoConfiguration {
-
-//    @Bean
-//    RouterFunction<ServerResponse> homeController() {
-//        return route(GET("/"), req -> ServerResponse.temporaryRedirect(URI.create("swagger-ui.html")).build());
-//    }
 
     @Bean
     HomeController homeController() {
@@ -33,5 +44,76 @@ public class ApiAutoConfiguration {
     @Bean
     CollectionsApiController collectionsApiController(CollectionsApiDelegate delegate) {
         return new CollectionsApiController(delegate);
+    }
+
+    /**
+     * Filter that replaces the {@literal Accept} request header by the MimeType of
+     * a matching collection items {@link MimeTypes supported format}, if the
+     * {@literal f} query parameter matches a {@link MimeTypes#getShortName() short
+     * name} supported output format.
+     * <p>
+     * E.g.: {@literal GET /ogcapi/collections/{collectionId}/items?f=shapefile}
+     * matches {@link MimeTypes#SHAPEFILE} and the Accept header is set to
+     * {@literal application/x-shapefile}
+     */
+    @Bean
+    FilterRegistrationBean<CollectionItemsFormatParamContentTypeFilter> forceItemsContentTypeFilter() {
+        FilterRegistrationBean<CollectionItemsFormatParamContentTypeFilter> registrationBean = new FilterRegistrationBean<>();
+
+        registrationBean.setFilter(new CollectionItemsFormatParamContentTypeFilter());
+        registrationBean.addUrlPatterns("/ogcapi/collections/*");
+        registrationBean.setOrder(-1);
+
+        return registrationBean;
+    }
+
+    static class CollectionItemsFormatParamContentTypeFilter implements Filter {
+
+        @Override
+        public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+                throws IOException, ServletException {
+
+            final HttpServletRequest httpreq = (HttpServletRequest) request;
+            final String requestURI = httpreq.getRequestURI();
+            final boolean isItemsRequest = requestURI.endsWith("/items");
+            if (!isItemsRequest) {
+                chain.doFilter(request, response);
+                return;
+            }
+
+            final String formatParam = request.getParameter("f");
+            final MimeTypes formatOverride;
+            if (formatParam != null) {
+                formatOverride = MimeTypes.findByShortName(formatParam).orElse(null);
+            } else {
+                String accept = httpreq.getHeader("Accept");
+                List<String> list = accept == null ? List.of() : Arrays.asList(accept.split(","));
+                boolean anyMatch = list.stream().filter(t -> !t.startsWith("*/*"))
+                        .anyMatch(reqType -> MimeTypes.find(reqType).isPresent());
+                formatOverride = anyMatch ? null : MimeTypes.GeoJSON;
+            }
+
+            if (formatOverride != null) {
+                HttpServletRequestWrapper w = new HttpServletRequestWrapper(httpreq) {
+                    final String formatMime = formatOverride.getMimeType().toString();
+
+                    public @Override Enumeration<String> getHeaders(String name) {
+                        if ("Accept".equalsIgnoreCase(name)) {
+                            return Collections.enumeration(List.of(formatMime));
+                        }
+                        return super.getHeaders(name);
+                    }
+
+                    public @Override String getHeader(String name) {
+                        if ("Accept".equalsIgnoreCase(name)) {
+                            return formatMime;
+                        }
+                        return super.getHeader(name);
+                    }
+                };
+                request = w;
+            }
+            chain.doFilter(request, response);
+        }
     }
 }

--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/http/codec/MimeTypes.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/http/codec/MimeTypes.java
@@ -8,33 +8,57 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.util.MimeType;
 
 import lombok.Getter;
+import lombok.NonNull;
 
 public enum MimeTypes {
 
-    SHAPEFILE(new MimeType("application", "x-shapefile")) {
+    JSON(new MimeType("application", "json"), "json", "JSON") {
+        public @Override void addHeaders(String collectionId, HttpHeaders headers) {
+        }
+    },
+    GeoJSON(new MimeType("application", "geo+json"), "geojson", "GeoJSON") {
+        public @Override void addHeaders(String collectionId, HttpHeaders headers) {
+        }
+    },
+    SHAPEFILE(new MimeType("application", "x-shapefile"), "shapefile", "Esri Shapefile") {
         public @Override void addHeaders(String collectionId, HttpHeaders headers) {
             contentDisposition(collectionId, "shp.zip", headers);
         }
     },
-    CSV(new MimeType("text", "csv", StandardCharsets.UTF_8)) {
+    CSV(new MimeType("text", "csv", StandardCharsets.UTF_8), "csv", "Comma Separated Values") {
         public @Override void addHeaders(String collectionId, HttpHeaders headers) {
             contentDisposition(collectionId, "csv", headers);
         }
     },
-    OOXML(new MimeType("application", "vnd.openxmlformats-officedocument.spreadsheetml.sheet")) {
+    OOXML(new MimeType("application", "vnd.openxmlformats-officedocument.spreadsheetml.sheet"), "ooxml",
+            "Excel 2007 / OOXML") {
         public @Override void addHeaders(String collectionId, HttpHeaders headers) {
             contentDisposition(collectionId, "xlsx", headers);
         }
     };
 
-    private final @Getter MimeType mimeType;
+    private final @Getter @NonNull MimeType mimeType;
+    private final @Getter @NonNull String shortName;
+    private final @Getter @NonNull String displayName;
 
-    private MimeTypes(MimeType type) {
+    private MimeTypes(MimeType type, String shortName, String displayName) {
         this.mimeType = type;
+        this.shortName = shortName;
+        this.displayName = displayName;
     }
 
-    public static Optional<MimeTypes> find(MimeType contentType) {
+    public static Optional<MimeTypes> find(@NonNull MimeType contentType) {
         return Arrays.stream(values()).filter(m -> m.getMimeType().isCompatibleWith(contentType)).findFirst();
+    }
+
+    public static Optional<MimeTypes> find(@NonNull String mimeType) {
+        MimeType contentType = MimeType.valueOf(mimeType);
+        return find(contentType);
+    }
+
+    public static Optional<MimeTypes> findByShortName(String parameter) {
+        return Optional.ofNullable(parameter)
+                .flatMap(p -> Arrays.stream(values()).filter(m -> m.getShortName().equals(p)).findFirst());
     }
 
     public abstract void addHeaders(String collectionId, HttpHeaders headers);

--- a/src/services/ogc-features/src/main/resources/application.yml
+++ b/src/services/ogc-features/src/main/resources/application.yml
@@ -1,6 +1,7 @@
 spring:
   application:
     name: ogc-features
+  jackson.default-property-inclusion: non-empty
 
 springdoc:
   # see https://springdoc.org/#how-can-i-disable-springdoc-openapi-cache
@@ -12,3 +13,7 @@ springdoc:
     enabled: true
     #path: ${openapi.geoServerACL.base-path}/swagger-ui.html
     try-it-out-enabled: true    
+
+logging:
+  level:
+    root: info


### PR DESCRIPTION
Add a servlet Filter that replaces the `Accept` request header by the MimeType of a matching collection items `MimeTypes` supported format, if the `f` query parameter matches a `MimeTypes#getShortName()` short name supported output format.

E.g.: `GET /ogcapi/collections/{collectionId}/items?f=shapefile` matches `MimeTypes#SHAPEFILE` and the Accept header is set to `application/x-shapefile`, resulting in a download of the collection in shapefile format and not in an error.