### PR TITLE
Use OpenAPI tag names to generage Java API interfaces

### DIFF
--- a/src/services/ogc-features/pom.xml
+++ b/src/services/ogc-features/pom.xml
@@ -153,6 +153,7 @@
                 <sourceFolder>src/main/java</sourceFolder>
                 <library>spring-boot</library>
                 <reactive>false</reactive>
+                <useTags>true</useTags>
                 <useSpringBoot3>true</useSpringBoot3>
                 <delegatePattern>true</delegatePattern>
                 <openApiNullable>false</openApiNullable>

--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/autoconfigure/api/ApiAutoConfiguration.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/autoconfigure/api/ApiAutoConfiguration.java
@@ -21,11 +21,16 @@ import com.camptocamp.opendata.ogc.features.http.codec.json.SimpleJsonFeatureCol
 import com.camptocamp.opendata.ogc.features.http.codec.shp.ShapefileFeatureCollectionHttpMessageConverter;
 import com.camptocamp.opendata.ogc.features.http.codec.xls.Excel2007FeatureCollectionHttpMessageConverter;
 import com.camptocamp.opendata.ogc.features.repository.CollectionRepository;
-import com.camptocamp.opendata.ogc.features.server.api.CollectionsApiController;
-import com.camptocamp.opendata.ogc.features.server.api.CollectionsApiDelegate;
+import com.camptocamp.opendata.ogc.features.server.api.CapabilitiesApi;
+import com.camptocamp.opendata.ogc.features.server.api.CapabilitiesApiController;
+import com.camptocamp.opendata.ogc.features.server.api.CapabilitiesApiDelegate;
+import com.camptocamp.opendata.ogc.features.server.api.DataApi;
+import com.camptocamp.opendata.ogc.features.server.api.DataApiController;
+import com.camptocamp.opendata.ogc.features.server.api.DataApiDelegate;
 import com.camptocamp.opendata.ogc.features.server.config.HomeController;
 import com.camptocamp.opendata.ogc.features.server.config.SpringDocConfiguration;
-import com.camptocamp.opendata.ogc.features.server.impl.CollectionsApiImpl;
+import com.camptocamp.opendata.ogc.features.server.impl.CapabilitiesApiImpl;
+import com.camptocamp.opendata.ogc.features.server.impl.DataApiImpl;
 
 import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
@@ -56,8 +61,23 @@ public class ApiAutoConfiguration implements WebMvcConfigurer {
     }
 
     @Bean
-    CollectionsApiController collectionsApiController(CollectionsApiDelegate delegate) {
-        return new CollectionsApiController(delegate);
+    CapabilitiesApiController capabilitiesApi(CapabilitiesApiDelegate delegate) {
+        return new CapabilitiesApiController(delegate);
+    }
+
+    @Bean
+    DataApiController collectionsApiController(DataApiDelegate delegate) {
+        return new DataApiController(delegate);
+    }
+
+    @Bean
+    CapabilitiesApiDelegate capabilitiesApiDelegate(CollectionRepository repo) {
+        return new CapabilitiesApiImpl(repo);
+    }
+
+    @Bean
+    DataApiDelegate collectionsApiDelegate(CollectionRepository repo) {
+        return new DataApiImpl(repo);
     }
 
     /**
@@ -93,11 +113,6 @@ public class ApiAutoConfiguration implements WebMvcConfigurer {
     @Bean
     CsvFeatureCollectionHttpMessageConverter csvFeatureCollectionHttpMessageConverter() {
         return new CsvFeatureCollectionHttpMessageConverter();
-    }
-
-    @Bean
-    CollectionsApiDelegate collectionsApiDelegate(CollectionRepository repo) {
-        return new CollectionsApiImpl(repo);
     }
 
     /**

--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/server/impl/CapabilitiesApiImpl.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/server/impl/CapabilitiesApiImpl.java
@@ -1,0 +1,114 @@
+package com.camptocamp.opendata.ogc.features.server.impl;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.camptocamp.opendata.ogc.features.http.codec.MimeTypes;
+import com.camptocamp.opendata.ogc.features.model.Collection;
+import com.camptocamp.opendata.ogc.features.model.Collections;
+import com.camptocamp.opendata.ogc.features.model.Link;
+import com.camptocamp.opendata.ogc.features.repository.CollectionRepository;
+import com.camptocamp.opendata.ogc.features.server.api.CapabilitiesApiDelegate;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CapabilitiesApiImpl implements CapabilitiesApiDelegate {
+
+    private final @NonNull CollectionRepository repository;
+
+    private @Autowired NativeWebRequest req;
+
+    @Override
+    public Optional<NativeWebRequest> getRequest() {
+        return Optional.of(req);
+    }
+
+    // TODO: implement
+//    @Override
+//    public ResponseEntity<LandingPage> getLandingPage() {
+//    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResponseEntity<Collections> getCollections() {
+        List<Collection> collections = repository.getCollections();
+        Collections body = createCollections(collections);
+        return ResponseEntity.ok(body);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public ResponseEntity<Collection> describeCollection(String collectionId) {
+        return repository.findCollection(collectionId).map(this::addLinks).map(ResponseEntity::ok)
+                .orElseGet(() -> ResponseEntity.notFound().build());
+    }
+
+    private Collections createCollections(List<Collection> collections) {
+        Collections cs = new Collections(new ArrayList<>(), collections);
+        addLinks(cs);
+        return cs;
+    }
+
+    private Collections addLinks(Collections collections) {
+        NativeWebRequest request = getRequest().orElseThrow();
+        HttpServletRequest nativeRequest = (HttpServletRequest) request.getNativeRequest();
+        String basePath = nativeRequest.getRequestURL().toString();
+        collections.getCollections().forEach(c -> {
+            String colBase = UriComponentsBuilder.fromUriString(basePath).pathSegment(c.getId()).build().toString();
+            addLinks(c, colBase);
+        });
+        return collections;
+    }
+
+    private Collection addLinks(Collection collection) {
+        NativeWebRequest request = getRequest().orElseThrow();
+        HttpServletRequest nativeRequest = (HttpServletRequest) request.getNativeRequest();
+        return addLinks(collection, nativeRequest.getRequestURL().toString());
+    }
+
+    private Collection addLinks(Collection collection, String baseUrl) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(baseUrl);
+        builder.pathSegment("items");
+
+        MimeTypes defFormat = MimeTypes.GeoJSON;
+        UriComponents itemsc = builder.replaceQueryParam("f", defFormat.getShortName()).build();
+        Link items = link(itemsc.toString(), "items", defFormat.getMimeType().toString(), collection.getId());
+        collection.addLinksItem(items);
+
+        Arrays.stream(MimeTypes.values()).forEach(m -> {
+            if (m.supportsItemType(collection.getItemType())) {
+                String href = builder.replaceQueryParam("f", m.getShortName()).replaceQueryParam("limit", "-1").build()
+                        .toString();
+                String type = m.getMimeType().toString();
+                String title = "Bulk download (%s)".formatted(m.getDisplayName());
+                Link link = link(href, "enclosure", type, title);
+                collection.addLinksItem(link);
+            }
+        });
+        return collection;
+    }
+
+    private Link link(String href, String rel, String type, String title) {
+        Link link = new Link(href);
+        link.setRel(rel);
+        link.setType(type);
+        link.setTitle(title);
+        return link;
+    }
+
+}

--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/server/impl/DataApiImpl.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/server/impl/DataApiImpl.java
@@ -2,7 +2,6 @@ package com.camptocamp.opendata.ogc.features.server.impl;
 
 import java.math.BigDecimal;
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
@@ -19,45 +18,25 @@ import org.springframework.web.util.UriComponentsBuilder;
 import com.camptocamp.opendata.model.DataQuery;
 import com.camptocamp.opendata.model.GeodataRecord;
 import com.camptocamp.opendata.ogc.features.http.codec.MimeTypes;
-import com.camptocamp.opendata.ogc.features.model.Collection;
-import com.camptocamp.opendata.ogc.features.model.Collections;
 import com.camptocamp.opendata.ogc.features.model.FeatureCollection;
 import com.camptocamp.opendata.ogc.features.model.Link;
 import com.camptocamp.opendata.ogc.features.repository.CollectionRepository;
-import com.camptocamp.opendata.ogc.features.server.api.CollectionsApiDelegate;
+import com.camptocamp.opendata.ogc.features.server.api.DataApiDelegate;
 
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-public class CollectionsApiImpl implements CollectionsApiDelegate {
+public class DataApiImpl implements DataApiDelegate {
 
     private final @NonNull CollectionRepository repository;
 
     private @Autowired NativeWebRequest req;
 
+    @Override
     public Optional<NativeWebRequest> getRequest() {
         return Optional.of(req);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public ResponseEntity<Collections> getCollections() {
-        List<Collection> collections = repository.getCollections();
-        Collections body = createCollections(collections);
-        return ResponseEntity.ok(body);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public ResponseEntity<Collection> describeCollection(String collectionId) {
-        return repository.findCollection(collectionId).map(this::addLinks).map(ResponseEntity::ok)
-                .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
     /**
@@ -122,51 +101,6 @@ public class CollectionsApiImpl implements CollectionsApiDelegate {
         return headers;
     }
 
-    private Collections createCollections(List<Collection> collections) {
-        Collections cs = new Collections(new ArrayList<>(), collections);
-        addLinks(cs);
-        return cs;
-    }
-
-    private Collections addLinks(Collections collections) {
-        NativeWebRequest request = getRequest().orElseThrow();
-        HttpServletRequest nativeRequest = (HttpServletRequest) request.getNativeRequest();
-        String basePath = nativeRequest.getRequestURL().toString();
-        collections.getCollections().forEach(c -> {
-            String colBase = UriComponentsBuilder.fromUriString(basePath).pathSegment(c.getId()).build().toString();
-            addLinks(c, colBase);
-        });
-        return collections;
-    }
-
-    private Collection addLinks(Collection collection) {
-        NativeWebRequest request = getRequest().orElseThrow();
-        HttpServletRequest nativeRequest = (HttpServletRequest) request.getNativeRequest();
-        return addLinks(collection, nativeRequest.getRequestURL().toString());
-    }
-
-    private Collection addLinks(Collection collection, String baseUrl) {
-        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(baseUrl);
-        builder.pathSegment("items");
-
-        MimeTypes defFormat = MimeTypes.GeoJSON;
-        UriComponents itemsc = builder.replaceQueryParam("f", defFormat.getShortName()).build();
-        Link items = link(itemsc.toString(), "items", defFormat.getMimeType().toString(), collection.getId());
-        collection.addLinksItem(items);
-
-        Arrays.stream(MimeTypes.values()).forEach(m -> {
-            if (m.supportsItemType(collection.getItemType())) {
-                String href = builder.replaceQueryParam("f", m.getShortName()).replaceQueryParam("limit", "-1").build()
-                        .toString();
-                String type = m.getMimeType().toString();
-                String title = "Bulk download (%s)".formatted(m.getDisplayName());
-                Link link = link(href, "enclosure", type, title);
-                collection.addLinksItem(link);
-            }
-        });
-        return collection;
-    }
-
     private FeatureCollection addLinks(FeatureCollection fc, DataQuery dataQuery) {
         NativeWebRequest request = getRequest().orElseThrow();
 
@@ -226,13 +160,12 @@ public class CollectionsApiImpl implements CollectionsApiDelegate {
 
         List<DataQuery.SortBy> sortby = query.sortBy();
 
-        DataQuery q = DataQuery.fromUri(URI.create("index://default"))//
+        return DataQuery.fromUri(URI.create("index://default"))//
                 .withLayerName(query.getCollectionId())//
                 .withLimit(query.getLimit())//
                 .withOffset(query.getOffset())//
                 .withFilter(query.getFilter())//
                 .withSortBy(sortby);
-        return q;
     }
 
 }

--- a/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/autoconfigure/ApiAutoConfigurationTest.java
+++ b/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/autoconfigure/ApiAutoConfigurationTest.java
@@ -12,8 +12,10 @@ import com.camptocamp.opendata.ogc.features.autoconfigure.geotools.SampleDataBac
 import com.camptocamp.opendata.ogc.features.http.codec.csv.CsvFeatureCollectionHttpMessageConverter;
 import com.camptocamp.opendata.ogc.features.http.codec.shp.ShapefileFeatureCollectionHttpMessageConverter;
 import com.camptocamp.opendata.ogc.features.http.codec.xls.Excel2007FeatureCollectionHttpMessageConverter;
-import com.camptocamp.opendata.ogc.features.server.api.CollectionsApiController;
-import com.camptocamp.opendata.ogc.features.server.api.CollectionsApiDelegate;
+import com.camptocamp.opendata.ogc.features.server.api.CapabilitiesApiController;
+import com.camptocamp.opendata.ogc.features.server.api.CapabilitiesApiDelegate;
+import com.camptocamp.opendata.ogc.features.server.api.DataApiController;
+import com.camptocamp.opendata.ogc.features.server.api.DataApiDelegate;
 import com.camptocamp.opendata.ogc.features.server.config.HomeController;
 
 class ApiAutoConfigurationTest {
@@ -27,7 +29,8 @@ class ApiAutoConfigurationTest {
     void testExpectedBeans() {
         runner.run(context -> {
             assertThat(context).hasNotFailed().hasSingleBean(HomeController.class)
-                    .hasSingleBean(CollectionsApiController.class).hasSingleBean(CollectionsApiDelegate.class)
+                    .hasSingleBean(CapabilitiesApiController.class).hasSingleBean(CapabilitiesApiDelegate.class)
+                    .hasSingleBean(DataApiController.class).hasSingleBean(DataApiDelegate.class)
                     .hasSingleBean(Excel2007FeatureCollectionHttpMessageConverter.class)
                     .hasSingleBean(ShapefileFeatureCollectionHttpMessageConverter.class)
                     .hasSingleBean(CsvFeatureCollectionHttpMessageConverter.class);

--- a/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/server/impl/CollectionsApiImplPostgisTest.java
+++ b/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/server/impl/CollectionsApiImplPostgisTest.java
@@ -123,7 +123,7 @@ class CollectionsApiImplPostgisTest extends AbstractCollectionsApiImplTest {
     }
 
     private Set<String> getCollectionNames() {
-        return collectionsApi.getCollections().getBody().getCollections().stream().map(Collection::getTitle)
+        return capabilitiesApi.getCollections().getBody().getCollections().stream().map(Collection::getTitle)
                 .collect(Collectors.toSet());
     }
 
@@ -180,7 +180,7 @@ class CollectionsApiImplPostgisTest extends AbstractCollectionsApiImplTest {
     void testGetItems_survives_schema_change() throws SQLException {
 
         FeaturesQuery query = FeaturesQuery.of("locations").withLimit(10);
-        ResponseEntity<FeatureCollection> response = collectionsApi.getFeatures(query);
+        ResponseEntity<FeatureCollection> response = dataApi.getFeatures(query);
 
         @Cleanup
         Stream<GeodataRecord> features = response.getBody().getFeatures();
@@ -188,14 +188,14 @@ class CollectionsApiImplPostgisTest extends AbstractCollectionsApiImplTest {
 
         renameColumn("locations", "year", "año");
 
-        response = collectionsApi.getFeatures(query);
+        response = dataApi.getFeatures(query);
         @Cleanup
         Stream<GeodataRecord> features1 = response.getBody().getFeatures();
         assertThat(features1).hasSize(10);
 
         dropColumn("locations", "año");
 
-        response = collectionsApi.getFeatures(query);
+        response = dataApi.getFeatures(query);
 
         @Cleanup
         Stream<GeodataRecord> features2 = response.getBody().getFeatures();
@@ -207,20 +207,20 @@ class CollectionsApiImplPostgisTest extends AbstractCollectionsApiImplTest {
         FeaturesQuery query = FeaturesQuery.of("locations").withLimit(1);
 
         @Cleanup
-        Stream<GeodataRecord> features = collectionsApi.getFeatures(query).getBody().getFeatures();
+        Stream<GeodataRecord> features = dataApi.getFeatures(query).getBody().getFeatures();
         GeodataRecord before = features.findFirst().orElseThrow();
         assertThat(before.getProperty("number")).isPresent();
         final String id = before.getId();
 
         renameColumn("locations", "number", "número");
 
-        GeodataRecord after = collectionsApi.getFeature("locations", id).getBody();
+        GeodataRecord after = dataApi.getFeature("locations", id).getBody();
         assertThat(after.getProperty("number")).isEmpty();
         assertThat(after.getProperty("número")).isPresent();
 
         dropColumn("locations", "número");
 
-        after = collectionsApi.getFeature("locations", id).getBody();
+        after = dataApi.getFeature("locations", id).getBody();
         assertThat(after.getProperty("número")).isEmpty();
     }
 

--- a/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/server/impl/DataApiImplTest.java
+++ b/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/server/impl/DataApiImplTest.java
@@ -17,7 +17,7 @@ import com.camptocamp.opendata.ogc.features.model.Link;
 
 @SpringBootTest(classes = OgcFeaturesApp.class)
 @ActiveProfiles("sample-data")
-class CollectionsApiImplTest extends AbstractCollectionsApiImplTest {
+class DataApiImplTest extends AbstractCollectionsApiImplTest {
 
     @Override
     protected Comparator<GeodataRecord> fidComparator() {
@@ -32,7 +32,7 @@ class CollectionsApiImplTest extends AbstractCollectionsApiImplTest {
         actualRequest.addHeader("Accept", "application/geo+json");
 
         FeaturesQuery query = FeaturesQuery.of("locations").withLimit(10);
-        ResponseEntity<FeatureCollection> response = collectionsApi.getFeatures(query);
+        ResponseEntity<FeatureCollection> response = dataApi.getFeatures(query);
 
         List<Link> links = response.getBody().getLinks();
         Link nextLink = links.stream().filter(l -> "next".equals(l.getRel())).findFirst().orElseThrow();
@@ -46,7 +46,7 @@ class CollectionsApiImplTest extends AbstractCollectionsApiImplTest {
         actualRequest.addHeader("Accept", "application/json");
 
         FeaturesQuery query = FeaturesQuery.of("locations").withLimit(10);
-        ResponseEntity<FeatureCollection> response = collectionsApi.getFeatures(query);
+        ResponseEntity<FeatureCollection> response = dataApi.getFeatures(query);
 
         List<Link> links = response.getBody().getLinks();
         Link nextLink = links.stream().filter(l -> "next".equals(l.getRel())).findFirst().orElseThrow();
@@ -58,8 +58,7 @@ class CollectionsApiImplTest extends AbstractCollectionsApiImplTest {
         actualRequest.addHeader("Accept", "application/json");
         actualRequest.setParameter("f", "ooxml");
 
-        ResponseEntity<FeatureCollection> response = collectionsApi
-                .getFeatures(FeaturesQuery.of("locations").withLimit(2));
+        ResponseEntity<FeatureCollection> response = dataApi.getFeatures(FeaturesQuery.of("locations").withLimit(2));
         List<Link> links = response.getBody().getLinks();
         Link nextLink = links.stream().filter(l -> "next".equals(l.getRel())).findFirst().orElseThrow();
         assertThat(nextLink.getHref()).contains("f=ooxml");


### PR DESCRIPTION
Add the `<useTags>true</useTags>` configuration option to the `openapi-generator-maven-plugin`, so it generates Java API interfaces based on the tags of each operation instead of using the URI paths.

This leads to the following refactoring of classes:

`CollectionsApi` -> `DataApi`
`DefaultApi` -> `CapabilitiesApi`

Additionally, some methods from the `DataApi` are moved to the `CapabilitiesApi`, as they're annotated with the `Capabilities` tag in the OpenAPI definition.