### PR TITLE
simple json output - instruct Jackson to ISO-8601 format dates

### DIFF
--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/http/codec/json/SimpleJsonFeatureCollectionHttpMessageConverter.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/http/codec/json/SimpleJsonFeatureCollectionHttpMessageConverter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Type;
 
+import com.fasterxml.jackson.databind.util.StdDateFormat;
 import org.springframework.http.HttpInputMessage;
 import org.springframework.http.HttpOutputMessage;
 import org.springframework.http.MediaType;
@@ -63,6 +64,7 @@ public class SimpleJsonFeatureCollectionHttpMessageConverter
     public SimpleJsonFeatureCollectionHttpMessageConverter() {
         super(MEDIA_TYPE);
         mapper = new ObjectMapper();
+        mapper.setDateFormat(new StdDateFormat());
         Jackson2ObjectMapperBuilder.json().configure(mapper);
         mapper.registerModule(new SimpleJsonModule());
     }

--- a/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/http/codec/json/SimpleJsonFeatureCollectionHttpMessageConverterTest.java
+++ b/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/http/codec/json/SimpleJsonFeatureCollectionHttpMessageConverterTest.java
@@ -1,0 +1,60 @@
+package com.camptocamp.opendata.ogc.features.http.codec.json;
+
+import com.camptocamp.opendata.ogc.features.model.Collection;
+import com.camptocamp.opendata.ogc.features.model.FeatureCollection;
+import com.camptocamp.opendata.ogc.features.model.GeoToolsFeatureCollection;
+import org.geotools.api.feature.simple.SimpleFeatureType;
+import org.geotools.data.simple.SimpleFeatureCollection;
+import org.geotools.feature.DefaultFeatureCollection;
+import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.http.MockHttpOutputMessage;
+
+import java.awt.*;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+public class SimpleJsonFeatureCollectionHttpMessageConverterTest {
+
+    private SimpleFeatureCollection features() {
+        SimpleFeatureBuilder fb = new SimpleFeatureBuilder(featureType());
+        DefaultFeatureCollection col = new DefaultFeatureCollection();
+        col.add(fb.buildFeature("1234", new java.sql.Timestamp(1714646315000L))); // ~ 2024-05-02 GMT+02
+
+        return col;
+    }
+
+    private SimpleFeatureType featureType() {
+        SimpleFeatureTypeBuilder builder = new SimpleFeatureTypeBuilder();
+        builder.setName("test");
+        builder.setNamespaceURI("http://test");
+        builder.setSRS("EPSG:4326");
+        builder.add("date", java.sql.Timestamp.class);
+        builder.add("pointProperty", Point.class);
+
+        return builder.buildFeatureType();
+    }
+
+    private FeatureCollection featureCollection() {
+        Collection col = new Collection("1234", List.of());
+        SimpleFeatureCollection features = features();
+        GeoToolsFeatureCollection collection = new GeoToolsFeatureCollection(col, features);
+        collection.setNumberMatched(1L);
+        collection.setNumberReturned(1L);
+
+        return collection;
+    }
+
+    @Test
+    public void testJavaSqlTimeStampsAsISO8601Dates() throws Exception {
+        SimpleJsonFeatureCollectionHttpMessageConverter converter = new SimpleJsonFeatureCollectionHttpMessageConverter();
+        MockHttpOutputMessage message = new MockHttpOutputMessage();
+
+        converter.writeInternal(featureCollection(), null, message);
+
+        assertThat(message.getBodyAsString(), containsString("2024-05-02T"));
+    }
+}


### PR DESCRIPTION
By default, Jackson will serialize everything related to `java.util.Date` as timestamp (e.g. `long`), making the simple json output incoherent with the geojson one for properties retrieved from the database as e.g. `java.sql.Timestamp`.

This PR aims to force Jackson to format dates as ISO8601 when serializing.

Tests:
* UT added

Note:
using string comparison to check if we actually have a date in the JSON output might not be the best way of testing this case, I haven't tested if using a remote timezone could make it fail, but I think the main intent is here.
