### PR TITLE
java21 support - bump lombok version

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -70,7 +70,7 @@
       <dependency>
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
-        <version>1.18.28</version>
+        <version>1.18.30</version>
         <scope>provided</scope>
       </dependency>
       <!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webflux-ui -->

--- a/src/services/ogc-features/pom.xml
+++ b/src/services/ogc-features/pom.xml
@@ -105,7 +105,7 @@
             <path>
               <groupId>org.projectlombok</groupId>
               <artifactId>lombok</artifactId>
-              <version>1.18.28</version>
+              <version>1.18.30</version>
             </path>
           </annotationProcessorPaths>
         </configuration>


### PR DESCRIPTION
Using the former version will make the build (`mvn clean verify`) fail, because of incompatibility with Java21.

tests: mvn clean verify OK