### PR TITLE
Add items type to paginable formats

### DIFF
--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/http/codec/MimeTypes.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/http/codec/MimeTypes.java
@@ -12,15 +12,15 @@ import lombok.NonNull;
 
 public enum MimeTypes {
 
-    JSON(new MimeType("application", "json"), "json", "JSON", true) {
+    JSON(new MimeType("application", "json"), "json", "JSON") {
         public @Override void addHeaders(String collectionId, HttpHeaders headers) {
         }
     },
-    GeoJSON(new MimeType("application", "geo+json"), "geojson", "GeoJSON", true) {
+    GeoJSON(new MimeType("application", "geo+json"), "geojson", "GeoJSON") {
         public @Override void addHeaders(String collectionId, HttpHeaders headers) {
         }
     },
-    SHAPEFILE(new MimeType("application", "x-shapefile"), "shapefile", "Esri Shapefile", false) {
+    SHAPEFILE(new MimeType("application", "x-shapefile"), "shapefile", "Esri Shapefile") {
         public @Override void addHeaders(String collectionId, HttpHeaders headers) {
             contentDisposition(collectionId, "shp.zip", headers);
         }
@@ -29,13 +29,13 @@ public enum MimeTypes {
             return "feature".equals(itemType);
         }
     },
-    CSV(new MimeType("text", "csv", StandardCharsets.UTF_8), "csv", "Comma Separated Values", true) {
+    CSV(new MimeType("text", "csv", StandardCharsets.UTF_8), "csv", "Comma Separated Values") {
         public @Override void addHeaders(String collectionId, HttpHeaders headers) {
             contentDisposition(collectionId, "csv", headers);
         }
     },
     OOXML(new MimeType("application", "vnd.openxmlformats-officedocument.spreadsheetml.sheet"), "ooxml",
-            "Excel 2007 / OOXML", false) {
+            "Excel 2007 / OOXML") {
         public @Override void addHeaders(String collectionId, HttpHeaders headers) {
             contentDisposition(collectionId, "xlsx", headers);
         }
@@ -44,13 +44,11 @@ public enum MimeTypes {
     private final @Getter @NonNull MimeType mimeType;
     private final @Getter @NonNull String shortName;
     private final @Getter @NonNull String displayName;
-    private final @Getter @NonNull boolean paginable;
 
-    private MimeTypes(MimeType type, String shortName, String displayName, boolean paginable) {
+    private MimeTypes(MimeType type, String shortName, String displayName) {
         this.mimeType = type;
         this.shortName = shortName;
         this.displayName = displayName;
-        this.paginable = paginable;
     }
 
     public static Optional<MimeTypes> find(@NonNull MimeType contentType) {

--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/http/codec/MimeTypes.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/http/codec/MimeTypes.java
@@ -12,15 +12,15 @@ import lombok.NonNull;
 
 public enum MimeTypes {
 
-    JSON(new MimeType("application", "json"), "json", "JSON") {
+    JSON(new MimeType("application", "json"), "json", "JSON", true) {
         public @Override void addHeaders(String collectionId, HttpHeaders headers) {
         }
     },
-    GeoJSON(new MimeType("application", "geo+json"), "geojson", "GeoJSON") {
+    GeoJSON(new MimeType("application", "geo+json"), "geojson", "GeoJSON", true) {
         public @Override void addHeaders(String collectionId, HttpHeaders headers) {
         }
     },
-    SHAPEFILE(new MimeType("application", "x-shapefile"), "shapefile", "Esri Shapefile") {
+    SHAPEFILE(new MimeType("application", "x-shapefile"), "shapefile", "Esri Shapefile", false) {
         public @Override void addHeaders(String collectionId, HttpHeaders headers) {
             contentDisposition(collectionId, "shp.zip", headers);
         }
@@ -29,13 +29,13 @@ public enum MimeTypes {
             return "feature".equals(itemType);
         }
     },
-    CSV(new MimeType("text", "csv", StandardCharsets.UTF_8), "csv", "Comma Separated Values") {
+    CSV(new MimeType("text", "csv", StandardCharsets.UTF_8), "csv", "Comma Separated Values", true) {
         public @Override void addHeaders(String collectionId, HttpHeaders headers) {
             contentDisposition(collectionId, "csv", headers);
         }
     },
     OOXML(new MimeType("application", "vnd.openxmlformats-officedocument.spreadsheetml.sheet"), "ooxml",
-            "Excel 2007 / OOXML") {
+            "Excel 2007 / OOXML", false) {
         public @Override void addHeaders(String collectionId, HttpHeaders headers) {
             contentDisposition(collectionId, "xlsx", headers);
         }
@@ -44,11 +44,13 @@ public enum MimeTypes {
     private final @Getter @NonNull MimeType mimeType;
     private final @Getter @NonNull String shortName;
     private final @Getter @NonNull String displayName;
+    private final @Getter @NonNull boolean paginable;
 
-    private MimeTypes(MimeType type, String shortName, String displayName) {
+    private MimeTypes(MimeType type, String shortName, String displayName, boolean paginable) {
         this.mimeType = type;
         this.shortName = shortName;
         this.displayName = displayName;
+        this.paginable = paginable;
     }
 
     public static Optional<MimeTypes> find(@NonNull MimeType contentType) {

--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/server/impl/CapabilitiesApiImpl.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/server/impl/CapabilitiesApiImpl.java
@@ -118,7 +118,7 @@ public class CapabilitiesApiImpl implements CapabilitiesApiDelegate {
         UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(baseUrl);
         builder.pathSegment("items");
 
-        Arrays.stream(MimeTypes.values()).filter(MimeTypes::isPaginable).forEach(m -> {
+        Arrays.stream(MimeTypes.values()).forEach(m -> {
             if (m.supportsItemType(collection.getItemType())) {
                 collection.addLinksItem(createItem(builder, m, collection.getId()));
             }


### PR DESCRIPTION
This PR adds items type to the collection in order to use it in an API querier.

Instead of having only geojson as unique `items` object in json response : 
```
class Collection {
    id: null
    title: null
    description: null
    links: [class Link {
        href: http://localhost:8080/api/v1/items?limit=&f=json
        rel: items
        type: application/json
        hreflang: null
        title: null
        length: null
    }, class Link {
        href: http://localhost:8080/api/v1/items?limit=&f=geojson
        rel: items
        type: application/geo+json
        hreflang: null
        title: null
        length: null
    }, class Link {
        href: http://localhost:8080/api/v1/items?limit=&f=csv
        rel: items
        type: text/csv;charset=UTF-8
        hreflang: null
        title: null
        length: null
    }, class Link {
        href: http://localhost:8080/api/v1/items?f=json&limit=-1
        rel: enclosure
        type: application/json
        hreflang: null
        title: Bulk download (JSON)
        length: null
    }, 
...
```