### PR TITLE
Add bbox filter to queries

### DIFF
--- a/src/library/data-functions/data-functions-core/src/main/java/com/camptocamp/opendata/model/DataQuery.java
+++ b/src/library/data-functions/data-functions-core/src/main/java/com/camptocamp/opendata/model/DataQuery.java
@@ -1,5 +1,6 @@
 package com.camptocamp.opendata.model;
 
+import java.math.BigDecimal;
 import java.net.URI;
 import java.util.Comparator;
 import java.util.List;
@@ -16,20 +17,21 @@ import lombok.experimental.Accessors;
 @Accessors(chain = true)
 public class DataQuery {
 
-    private @NonNull DataSource source;
-    private String layerName;
-    private Integer offset;
-    private Integer limit;
-    private String filter;
-    private @NonNull List<SortBy> sortBy;
-    private String targetCrs;
+    @NonNull DataSource source;
+    String layerName;
+    Integer offset;
+    Integer limit;
+    String filter;
+    @NonNull List<SortBy> sortBy;
+    String targetCrs;
+    List<BigDecimal> bbox;
 
     public static DataQuery fromUri(URI dataUri) {
         DataSource dataSource = DataSource.fromUri(dataUri);
         return DataQuery.builder().source(dataSource).sortBy(List.of()).build();
     }
 
-    public static record SortBy(String propertyName, boolean ascending) implements Comparator<GeodataRecord> {
+    public record SortBy(String propertyName, boolean ascending) implements Comparator<GeodataRecord> {
 
     @SuppressWarnings("unchecked")
     @Override

--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/repository/DataStoreCollectionRepository.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/repository/DataStoreCollectionRepository.java
@@ -168,6 +168,12 @@ public class DataStoreCollectionRepository implements CollectionRepository {
                 throw new IllegalArgumentException("Unable to parse ECQL filter", e);
             }
         }
+        if (null != query.getBbox()) {
+            var bbox_filter = ff.bbox(query.getLayerName(), query.getBbox().get(0).doubleValue(),
+                    query.getBbox().get(1).doubleValue(), query.getBbox().get(2).doubleValue(),
+                    query.getBbox().get(3).doubleValue(), query.getTargetCrs());
+            q.setFilter(q.getFilter() != null ? ff.and(q.getFilter(), bbox_filter) : bbox_filter);
+        }
         List<SortBy> sortBy = sortBy(query);
         if (null != limit || null != offset) {
             // always add natural order for paging consistency

--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/server/impl/DataApiImpl.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/server/impl/DataApiImpl.java
@@ -7,6 +7,7 @@ import java.math.BigDecimal;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import org.springframework.http.HttpHeaders;
@@ -97,7 +98,7 @@ public class DataApiImpl implements DataApiDelegate {
     private HttpHeaders getFeaturesHeaders(String collectionId) {
         HttpHeaders headers = new HttpHeaders();
 
-        getRequest().map(req -> Arrays.stream(req.getHeader(ACCEPT).split(",")).findFirst().get())
+        getRequest().map(req -> Arrays.stream(Objects.requireNonNull(req.getHeader(ACCEPT)).split(",")).findFirst().get())
                 .map(MimeType::valueOf).flatMap(MimeTypes::find).ifPresent(m -> m.addHeaders(collectionId, headers));
         return headers;
     }
@@ -167,7 +168,7 @@ public class DataApiImpl implements DataApiDelegate {
                 .withLimit(query.getLimit())//
                 .withOffset(query.getOffset())//
                 .withFilter(query.getFilter())//
-                .withSortBy(sortby).withTargetCrs(query.getCrs());
+                .withSortBy(sortby).withTargetCrs(query.getCrs()).withBbox(query.getBbox());
     }
 
 }

--- a/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/server/impl/CollectionsApiIT.java
+++ b/src/services/ogc-features/src/test/java/com/camptocamp/opendata/ogc/features/server/impl/CollectionsApiIT.java
@@ -250,4 +250,71 @@ class CollectionsApiIT {
 
         JSONAssert.assertEquals(expected, response.getBody(), false);
     }
+
+    @Test
+    void testGetItemsWithBBoxFilter() throws JSONException {
+        final String url = itemsUrlTemplate + "&bbox=-2.416992,42.908160,8.613281,51.508742";
+        Map<String, String> urlVariables = Map.of("collection", "locations", "f", "geojson");
+        ResponseEntity<String> response = restTemplate.getForEntity(url, String.class, urlVariables);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getHeaders().getContentType()).isEqualTo(MediaType.parseMediaType("application/geo+json"));
+        String expected = """
+                {
+                  "type": "FeatureCollection",
+                  "numberMatched": -1,
+                  "numberReturned": -1,
+                  "features": [
+                    {
+                      "type": "Feature",
+                      "@typeName": "locations",
+                      "@id": "15",
+                      "geometry": {"type": "Point","@name": "geom","@srs": "EPSG:4326","coordinates": [7.099814,50.733992]},
+                      "properties": {"city": "Bonn","number": 700,"year": 2016}
+                    },
+                    {
+                      "type": "Feature",
+                      "@typeName": "locations",
+                      "@id": "6",
+                      "geometry": {"type": "Point","@name": "geom","@srs": "EPSG:4326","coordinates": [6.6335,46.519833]},
+                      "properties": {"city": " Lausanne","number": 560,"year": 2006}
+                    }
+                  ],
+                  "links": [
+                    {
+                      "href": "http://localhost:<port>/ogcapi/collections/locations/items?f=geojson&bbox=-2.416992,42.908160,8.613281,51.508742",
+                      "rel": "self",
+                      "type": "application/geo+json",
+                      "title": "This document"
+                    },
+                    {
+                      "href": "http://localhost:<port>/ogcapi/collections/locations/items?bbox=-2.416992,42.908160,8.613281,51.508742&f=json",
+                      "rel": "alternate",
+                      "type": "application/json",
+                      "title": "This document as JSON"
+                    },
+                    {
+                      "href": "http://localhost:<port>/ogcapi/collections/locations/items?bbox=-2.416992,42.908160,8.613281,51.508742&f=shapefile",
+                      "rel": "alternate",
+                      "type": "application/x-shapefile",
+                      "title": "This document as Esri Shapefile"
+                    },
+                    {
+                      "href": "http://localhost:<port>/ogcapi/collections/locations/items?bbox=-2.416992,42.908160,8.613281,51.508742&f=csv",
+                      "rel": "alternate",
+                      "type": "text/csv;charset=UTF-8",
+                      "title": "This document as Comma Separated Values"
+                    },
+                    {
+                      "href": "http://localhost:<port>/ogcapi/collections/locations/items?bbox=-2.416992,42.908160,8.613281,51.508742&f=ooxml",
+                      "rel": "alternate",
+                      "type": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                      "title": "This document as Excel 2007 / OOXML"
+                    }
+                  ]
+                }
+                """
+                .replaceAll("<port>", String.valueOf(port));
+
+        JSONAssert.assertEquals(expected, response.getBody(), false);
+    }
 }


### PR DESCRIPTION
Request can be set with bbox filters on items : `bbox=-2.416992,42.908160,8.613281,51.508742`


@Value marks non static, package-local fields private. Solves some warnings