### PR TITLE
Allow to enable cors with configuration

### DIFF
--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/autoconfigure/api/ApiAutoConfiguration.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/autoconfigure/api/ApiAutoConfiguration.java
@@ -193,18 +193,20 @@ public class ApiAutoConfiguration implements WebMvcConfigurer {
     }
 
     @Value("${cors.allowed-origins:}")
-    private String allowedOrigins;
+    private String[] allowedOrigins;
 
     @Value("${cors.allowed-methods:*}")
-    private String allowedMethods;
+    private String[] allowedMethods;
 
     @ConditionalOnProperty(name = "cors", havingValue = "true")
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        if (allowedOrigins.isEmpty()) {
+        if (allowedOrigins.length == 0) {
+            log.warn("CORS disabled");
             return;
         }
-        log.info("CORS enabled for origins: " + allowedOrigins + " methods: " + allowedMethods);
-        registry.addMapping("/**").allowedMethods(allowedMethods.split(",")).allowedOrigins(allowedOrigins.split(","));
+        log.warn("CORS enabled for origins: " + Arrays.toString(allowedOrigins) + " methods: "
+                + Arrays.toString(allowedMethods));
+        registry.addMapping("/**").allowedMethods(allowedMethods).allowedOrigins(allowedOrigins);
     }
 }

--- a/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/autoconfigure/api/ApiAutoConfiguration.java
+++ b/src/services/ogc-features/src/main/java/com/camptocamp/opendata/ogc/features/autoconfigure/api/ApiAutoConfiguration.java
@@ -8,7 +8,10 @@ import java.util.Collections;
 import java.util.Enumeration;
 import java.util.List;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -55,6 +58,7 @@ import jakarta.servlet.http.HttpServletRequestWrapper;
  */
 @AutoConfiguration
 @Import(SpringDocConfiguration.class)
+@Slf4j
 public class ApiAutoConfiguration implements WebMvcConfigurer {
 
     @Bean
@@ -188,8 +192,19 @@ public class ApiAutoConfiguration implements WebMvcConfigurer {
         }
     }
 
+    @Value("${cors.allowed-origins:}")
+    private String allowedOrigins;
+
+    @Value("${cors.allowed-methods:*}")
+    private String allowedMethods;
+
+    @ConditionalOnProperty(name = "cors", havingValue = "true")
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**").allowedMethods("*");
+        if (allowedOrigins.isEmpty()) {
+            return;
+        }
+        log.info("CORS enabled for origins: " + allowedOrigins + " methods: " + allowedMethods);
+        registry.addMapping("/**").allowedMethods(allowedMethods.split(",")).allowedOrigins(allowedOrigins.split(","));
     }
 }

--- a/src/services/ogc-features/src/main/resources/application.yml
+++ b/src/services/ogc-features/src/main/resources/application.yml
@@ -19,7 +19,7 @@ springdoc:
     try-it-out-enabled: true
 
 #cors:
-#  allowed-origins: "*"
+#  allowed-origins: "*, https://localhost:8080"
 #  allowed-methods: GET, POST, PUT, DELETE, OPTIONS
 
 logging:

--- a/src/services/ogc-features/src/main/resources/application.yml
+++ b/src/services/ogc-features/src/main/resources/application.yml
@@ -18,6 +18,10 @@ springdoc:
     #path: swagger-ui/index.html
     try-it-out-enabled: true
 
+#cors:
+#  allowed-origins: "*"
+#  allowed-methods: GET, POST, PUT, DELETE, OPTIONS
+
 logging:
   level:
     root: info


### PR DESCRIPTION
Cors was configured with * which wasn't suitable. 

It can now be enabled with configuration files : 
```
cors:
  allowed-origins: "*"
  allowed-methods: GET, POST, PUT, DELETE, OPTIONS
```

It disabled by default.