### PR TITLE
chore: set default datadir location

### DIFF
--- a/src/services/ogc-features/src/main/resources/application.yml
+++ b/src/services/ogc-features/src/main/resources/application.yml
@@ -71,4 +71,4 @@ postgis:
 spring:
   config:
     # See https://github.com/georchestra/datadir/tree/master/gateway for a configuration override example
-    import: optional:file:${dataapi.configdir}/data-api/application.yaml
+    import: optional:file:${dataapi.configdir:/etc/georchestra}/data-api/application.yaml


### PR DESCRIPTION
Since data api is a product part of geOrchestra, we should set the same standard directory for the datadir.

The purpose of this PR is to set the default geOrchestra datadir location. In order to avoid having to specify it in all our deployments.

It's similar to https://github.com/georchestra/georchestra-gateway/pull/147